### PR TITLE
[Review] Docker Integration for developement

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+data/
+scripts/
+.git
+.gitignore
+Dockerfile*
+Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,127 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Other 
+data/tripadvisor/json/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# An integration test & dev container which builds and installs Wordbatch from master
+ARG VERSION_ID=16.04
+FROM ubuntu:${VERSION_ID}
+
+RUN apt-get update -y \
+    && apt-get upgrade -y \
+    && apt install -y gcc \
+    && apt-get install -y --reinstall build-essential
+      
+# Install conda
+ADD https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh /miniconda.sh
+RUN sh /miniconda.sh -b -p /conda && /conda/bin/conda update -n base conda
+ENV PATH=${PATH}:/conda/bin
+# Enables "source activate conda"
+SHELL ["/bin/bash", "-c"]
+
+# Add everything from the local build context
+ADD . /wordbatch/
+
+# Create conda env 
+RUN conda env create --name wordbatch_dev --file /wordbatch/conda/environments/wordbatch_dev.yml
+
+# Wordbatch build/install
+RUN source activate wordbatch_dev \
+    && cd wordbatch \ 
+    && python setup.py install \
+    && pip install ray 
+
+# set working directory to wordbatch/ when launch container
+WORKDIR wordbatch

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+IMAGE_NAME=wordbatch
+CONTAINER_NAME=wordbatch_dev
+
+build: ## Build the image
+	docker build -t $(IMAGE_NAME) .
+
+run-dev: ## Run container for development
+	docker run \
+		-it \
+		--ipc=host \
+		--name=$(CONTAINER_NAME) \
+		-v $(shell pwd):/wordbatch $(IMAGE_NAME) bash
+		
+attach: ## Run a bash in a running container
+	docker start $(CONTAINER_NAME) && docker attach $(CONTAINER_NAME)
+
+stop: ## Stop and remove a running container
+	docker stop $(CONTAINER_NAME); docker rm $(CONTAINER_NAME)

--- a/conda/environments/wordbatch_dev.yml
+++ b/conda/environments/wordbatch_dev.yml
@@ -1,6 +1,5 @@
 name: wordbatch_dev
 channels:
-  - bioconda
   - conda-forge
   - defaults
 dependencies:

--- a/conda/environments/wordbatch_dev.yml
+++ b/conda/environments/wordbatch_dev.yml
@@ -1,0 +1,16 @@
+name: wordbatch_dev
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - python>=3.6,<3.8
+  - numpy==1.17.4
+  - cython>=0.29,<0.30
+  - pip
+  - nltk==3.4.5
+  - textblob==0.13.0
+  - keras==2.3.1
+  - pyspark==2.4.0
+  - dask>=2.1.0
+  - distributed>=2.1.0


### PR DESCRIPTION
Added files for Docker Integration:
1. `.dockerignore` 
2. `.gitignore`
3.  `conda/environments/wordbatch_dev.yml` configuration for conda env 
4.  `Dockerfile`
5.  `Makefile` for container management 
     - **build**: build image
     - **run-dev**: launch container in bash mode   
     - **attach**: attach container
     - **stop**: stop-remove container

Docker Image for Wordbatch can be used as follows:
`sudo make build`
`sudo make run-dev `
`sudo make stop`

 **Note**: Accessing the container using bash user needs to activate conda env running `source activate wordbatch_dev` 